### PR TITLE
Correct image orientation before WebP conversion

### DIFF
--- a/webpCreate
+++ b/webpCreate
@@ -223,7 +223,7 @@ ask_conflict(){
 
 # ─── Convert + Conflict Handler ─────────────────────────────────────────────────
 convert_and_handle_conflict(){
-  local input=$1 base out newW newH w h suffix temp_input
+  local input=$1 base out newW newH w h suffix temp_input orientation rotate_degrees rotated
   base=${input%.*}
   suffix=$([ "$do_resize" = true ] && echo "-$maxDim" || echo "")
   out="${base}${suffix}.webp"
@@ -345,6 +345,30 @@ convert_and_handle_conflict(){
       fi
       ;;
   esac
+
+  # Map orientation codes to rotation degrees and fix pixels/dimensions
+  orientation=$(detect_orientation "$temp_input")
+  case "$orientation" in
+    6) rotate_degrees=90 ;;
+    3) rotate_degrees=180 ;;
+    8) rotate_degrees=270 ;;
+    *) rotate_degrees=0 ;;
+  esac
+
+  if (( rotate_degrees != 0 )); then
+    rotated="${base}_rot.jpg"
+    sips -r $rotate_degrees "$temp_input" --out "$rotated" >/dev/null 2>&1
+    sips -s orientation 1 "$rotated" >/dev/null 2>&1
+    if [[ "$temp_input" != "$input" ]]; then
+      rm -f "$temp_input"
+    fi
+    temp_input="$rotated"
+    if $do_resize && (( rotate_degrees == 90 || rotate_degrees == 270 )); then
+      local tmp=$newW
+      newW=$newH
+      newH=$tmp
+    fi
+  fi
 
   mkdir -p WEBP
   if [[ -e WEBP/$out ]]; then


### PR DESCRIPTION
## Summary
- map EXIF orientation codes to rotation degrees
- rotate temp files and swap resize dimensions when needed

## Testing
- `zsh -n webpCreate` *(failed: command not found)*
- `apt-get update` *(failed: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689a8ea746d08322979e3d4c72bd2f0b